### PR TITLE
feat(snap): add content interface for device configuration

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -30,3 +30,41 @@ The service can then be started as follows:
 ```bash
 $ sudo snap start edgex-device-mqtt.device-mqtt
 ```
+
+### Using a content interface to set device configuration
+
+The `device-config` content interface allows another snap to seed this device
+snap with both a configuration file and one or more device profiles.
+
+To use, create a new snap with a directory containing the configuration and device 
+profile files. Your snapcraft.yaml file then needs to define a slot with 
+read access to the directory you are sharing.
+
+```
+slots:
+  device-config:
+    interface: content
+    content: device-config
+    write:
+      - $SNAP/config
+```
+
+where `$SNAP/config` is configuration directory your snap is providing to 
+the device snap.
+
+Then connect the plug in the device snap to the slot in your snap,
+which will replace the configuration in the device snap. Do this with:
+
+```bash
+$ sudo snap connect edgex-device-mqtt:device-config your-snap:device-config
+```
+
+This needs to be done before the device service is started for the first time. 
+Once you have set the configuration the device service can be started and 
+it will then be configurated using the settings you provided:
+
+```bash
+$ sudo snap start edgex-device-mqtt.device-mqtt
+```
+
+**Note** - content interfaces from snaps installed from the Snap Store that have the same publisher connect automatically. For more information on snap content interfaces please refer to the snapcraft.io [Content Interface](https://snapcraft.io/docs/content-interface) documentation.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,11 @@ apps:
       WRITABLE_LOGLEVEL: 'INFO'
     daemon: simple
     plugs: [network, network-bind]
-
+plugs:
+  device-config:
+    interface: content 
+    content: device-config
+    target: $SNAP_DATA/config/device-mqtt/res
 parts:
   version:
     plugin: nil


### PR DESCRIPTION
The `device-config` content interface allows another snap to seed this device
snap with initial configuration and device profiles. To use, create a new
snap with the following in snapcraft.yaml:

```
slots:
  device-config:
    interface: content
    read: $SNAP_DATA/device-profiles
```

where device-profiles is the name of a directory with the new configuration
for the device snap. You can then connect the plug in the device snap to
the slot in your snap, which will replace the configuration in the device snap.
Do this with:

```
sudo snap connect edgex-device-mqtt:device-config your-snap:device-config
```

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
