### PR TITLE
fix(snap): move autostart logic to config hook

### DIFF
--- a/hooks/cmd/configure/configure.go
+++ b/hooks/cmd/configure/configure.go
@@ -21,6 +21,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	local "github.com/canonical/device-mqtt-go/hooks"
 	hooks "github.com/canonical/edgex-snap-hooks"
@@ -42,13 +43,13 @@ func main() {
 		debug = true
 	}
 
-	if err = hooks.Init(debug, "device-mqtt"); err != nil {
+	if err = hooks.Init(debug, "edgex-device-mqtt"); err != nil {
 		fmt.Println(fmt.Sprintf("edgex-device-mqtt:configure: initialization failure: %v", err))
 		os.Exit(1)
 
 	}
 
-	cli := hooks.NewSnapCtl()
+	// read env var override configuration
 	envJSON, err = cli.Config(hooks.EnvConfig)
 	if err != nil {
 		hooks.Error(fmt.Sprintf("Reading config 'env' failed: %v", err))
@@ -62,5 +63,40 @@ func main() {
 			hooks.Error(fmt.Sprintf("HandleEdgeXConfig failed: %v", err))
 			os.Exit(1)
 		}
+	}
+
+	// If autostart is not explicitly set, default to "no"
+	// as only example service configuration and profiles
+	// are provided by default.
+	autostart, err := cli.Config(hooks.AutostartConfig)
+	if err != nil {
+		hooks.Error(fmt.Sprintf("Reading config 'autostart' failed: %v", err))
+		os.Exit(1)
+	}
+	if autostart == "" {
+		hooks.Debug("edgex-device-mqtt autostart is NOT set, initializing to 'no'")
+		autostart = "no"
+	}
+	autostart = strings.ToLower(autostart)
+
+	hooks.Debug(fmt.Sprintf("edgex-device-mqtt autostart is %s", autostart))
+
+	// service is stopped/disabled by default in the install hook
+	switch autostart {
+	case "true":
+		fallthrough
+	case "yes":
+		err = cli.Start("device-mqtt", true)
+		if err != nil {
+			hooks.Error(fmt.Sprintf("Can't start service - %v", err))
+			os.Exit(1)
+		}
+	case "false":
+	     // no action necessary
+	case "no":
+	     // no action necessary
+	default:
+		hooks.Error(fmt.Sprintf("Invalid value for 'autostart' : %s", autostart))
+		os.Exit(1)
 	}
 }

--- a/snap/local/runtime-helpers/bin/debug.sh
+++ b/snap/local/runtime-helpers/bin/debug.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -ex
-
-debug=$(snapctl get debug)
-logger "device-mqtt: debug: $debug"
-
-autostart=$(snapctl get autostart)
-logger "device-mqtt: autostart: $autostart"
-
-exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,12 +22,6 @@ confinement: strict
 # edinburgh release is epoch 1
 epoch: 1
 
-passthrough:
-  hooks:
-    install:
-      command-chain:
-        - bin/debug.sh
-
 apps:
   device-mqtt:
     adapter: none


### PR DESCRIPTION
Since snapd doesn't make default snap configuration
from the gadget snap available to the install hook,
this change moves the autostart logic to the config
hook, and also modifies the install hook to always
stop/disable the service.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
